### PR TITLE
fix: use `multiprocess` instead of `multiprocessing` on macOS

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages = doit_auto1
 python_requires = >=3.8
 install_requires =
     macfsevents;sys_platform=='darwin'
+    multiprocess;sys_platform=='darwin'
     pyinotify;sys_platform=='linux'
 
 [options.entry_points]

--- a/src/doit_auto1/cmd_auto.py
+++ b/src/doit_auto1/cmd_auto.py
@@ -4,7 +4,7 @@ automatically execute tasks when file dependencies change"""
 import os
 import time
 import sys
-from multiprocessing import Process
+from multiprocess import Process
 from subprocess import call
 
 from doit.exceptions import InvalidCommand


### PR DESCRIPTION

This PR attempts to port what was initiated in https://github.com/pydoit/doit/pull/368 to the new plugin architecture of [`doit`](https://github.com/pydoit/doit).

Fixes: https://github.com/pydoit/doit/issues/372